### PR TITLE
Add CPU/GPU temperature monitoring during game sessions

### DIFF
--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -158,7 +158,8 @@ except ImportError:
 try:
     from pyadl import ADLManager
     PYADL_AVAILABLE = True
-except ImportError:
+except Exception:
+    # pyadl raises ADLError if no AMD GPU/driver found, not just ImportError
     PYADL_AVAILABLE = False
 
 # CPU temperature via WMI (requires LibreHardwareMonitor or OpenHardwareMonitor running)


### PR DESCRIPTION
pyadl raises ADLError (not ImportError) when AMD drivers aren't found. Changed to catch all exceptions so it gracefully falls back on NVIDIA-only systems.

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM