### PR TITLE
Add immediate admin elevation when CPU thermal is enabled

### DIFF
--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -210,17 +210,20 @@ def request_admin_restart():
         return False  # Already admin, no need to restart
 
     try:
-        # Get the executable path
+        # Get the executable path and working directory
         if getattr(sys, 'frozen', False):
             executable = sys.executable
             params = ' '.join(sys.argv[1:])
+            work_dir = os.path.dirname(sys.executable)
         else:
             executable = sys.executable
-            params = f'"{os.path.abspath(__file__)}" ' + ' '.join(sys.argv[1:])
+            script_path = os.path.abspath(__file__)
+            params = f'"{script_path}" ' + ' '.join(sys.argv[1:])
+            work_dir = os.path.dirname(script_path)
 
         # Request elevation using ShellExecute with 'runas'
         result = ctypes.windll.shell32.ShellExecuteW(
-            None, "runas", executable, params, None, 1
+            None, "runas", executable, params, work_dir, 1
         )
 
         # ShellExecuteW returns > 32 on success


### PR DESCRIPTION
- Settings UI now prompts for admin restart when enabling CPU thermal
- Added is_admin() and restart_vapor_as_admin() to settings UI
- Fixed request_admin_restart() to set working directory correctly
- This prevents the elevated process from failing to find required files

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM