### PR TITLE
Add reusable Vapor-styled dialog and fix console window

### DIFF
--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -216,7 +216,13 @@ def request_admin_restart():
             params = ' '.join(sys.argv[1:])
             work_dir = os.path.dirname(sys.executable)
         else:
-            executable = sys.executable
+            # Use pythonw.exe to avoid console window when elevated
+            python_dir = os.path.dirname(sys.executable)
+            pythonw_exe = os.path.join(python_dir, 'pythonw.exe')
+            if os.path.exists(pythonw_exe):
+                executable = pythonw_exe
+            else:
+                executable = sys.executable
             script_path = os.path.abspath(__file__)
             params = f'"{script_path}" ' + ' '.join(sys.argv[1:])
             work_dir = os.path.dirname(script_path)

--- a/vapor_settings_ui.py
+++ b/vapor_settings_ui.py
@@ -97,8 +97,14 @@ def restart_vapor_as_admin(main_pid):
             executable = os.path.join(os.path.dirname(sys.executable), 'steam_game_detector.exe')
             params = ""
     else:
-        # Running from Python - use python interpreter with script
-        executable = sys.executable
+        # Running from Python - use pythonw.exe to avoid console window
+        # pythonw.exe is the windowless version of python.exe
+        python_dir = os.path.dirname(sys.executable)
+        pythonw_exe = os.path.join(python_dir, 'pythonw.exe')
+        if os.path.exists(pythonw_exe):
+            executable = pythonw_exe
+        else:
+            executable = sys.executable
         main_script = os.path.join(base_dir, 'steam_game_detector.py')
         params = f'"{main_script}"'
 
@@ -110,6 +116,141 @@ def restart_vapor_as_admin(main_pid):
         return result > 32  # ShellExecuteW returns > 32 on success
     except Exception:
         return False
+
+
+# =============================================================================
+# Vapor Styled Dialog
+# =============================================================================
+
+def show_vapor_dialog(title, message, dialog_type="info", buttons=None, parent=None):
+    """
+    Show a Vapor-themed dialog popup that matches the app's style.
+
+    Args:
+        title: Dialog window title
+        message: Message text to display
+        dialog_type: "info", "warning", "error", or "question"
+        buttons: List of button configs, e.g. [{"text": "Yes", "value": True, "color": "green"}, ...]
+                 If None, defaults to a single "OK" button
+        parent: Parent window (optional)
+
+    Returns:
+        The value associated with the clicked button, or None if closed
+    """
+    result = [None]  # Use list to allow modification in nested function
+
+    # Create popup window
+    dialog = ctk.CTkToplevel(parent) if parent else ctk.CTk()
+    dialog.title(f"Vapor - {title}")
+    dialog.resizable(False, False)
+
+    # Calculate size based on message length
+    width = 500
+    height = 280 + (message.count('\n') * 10)
+    height = min(height, 500)  # Cap max height
+
+    dialog.geometry(f"{width}x{height}")
+
+    # Center on screen
+    dialog.update_idletasks()
+    screen_width = dialog.winfo_screenwidth()
+    screen_height = dialog.winfo_screenheight()
+    x = (screen_width - width) // 2
+    y = (screen_height - height) // 2
+    dialog.geometry(f"{width}x{height}+{x}+{y}")
+
+    # Set window icon
+    icon_path = os.path.join(base_dir, 'Images', 'exe_icon.ico')
+    if os.path.exists(icon_path):
+        try:
+            dialog.iconbitmap(icon_path)
+        except Exception:
+            pass
+
+    # Make dialog modal
+    dialog.transient(parent)
+    dialog.grab_set()
+
+    # Title label with appropriate color based on type
+    title_colors = {
+        "info": ("white", None),
+        "warning": ("orange", None),
+        "error": ("#ff6b6b", None),
+        "question": ("white", None)
+    }
+    title_color = title_colors.get(dialog_type, ("white", None))[0]
+
+    title_label = ctk.CTkLabel(
+        master=dialog,
+        text=title,
+        font=("Calibri", 20, "bold"),
+        text_color=title_color
+    )
+    title_label.pack(pady=(25, 15))
+
+    # Message label
+    message_label = ctk.CTkLabel(
+        master=dialog,
+        text=message,
+        font=("Calibri", 12),
+        justify="left",
+        wraplength=450
+    )
+    message_label.pack(pady=(0, 20), padx=25)
+
+    # Button frame
+    button_frame = ctk.CTkFrame(master=dialog, fg_color="transparent")
+    button_frame.pack(pady=(10, 25))
+
+    # Default buttons if none specified
+    if buttons is None:
+        buttons = [{"text": "OK", "value": True, "color": "green"}]
+
+    def make_button_callback(value):
+        def callback():
+            result[0] = value
+            dialog.destroy()
+        return callback
+
+    # Create buttons
+    for btn_config in buttons:
+        btn_text = btn_config.get("text", "OK")
+        btn_value = btn_config.get("value", None)
+        btn_color = btn_config.get("color", "gray")
+
+        # Map color names to actual colors
+        color_map = {
+            "green": ("#2ecc71", "#27ae60"),
+            "red": ("#e74c3c", "#c0392b"),
+            "gray": ("gray", "#555555"),
+            "blue": ("#3498db", "#2980b9"),
+            "orange": ("#f39c12", "#d68910")
+        }
+        fg_color, hover_color = color_map.get(btn_color, ("gray", "#555555"))
+
+        btn = ctk.CTkButton(
+            master=button_frame,
+            text=btn_text,
+            command=make_button_callback(btn_value),
+            width=140,
+            height=35,
+            corner_radius=10,
+            fg_color=fg_color,
+            hover_color=hover_color,
+            font=("Calibri", 14)
+        )
+        btn.pack(side="left", padx=10)
+
+    # Handle window close button (X)
+    dialog.protocol("WM_DELETE_WINDOW", lambda: (result.__setitem__(0, None), dialog.destroy()))
+
+    # Wait for dialog to close
+    if parent:
+        dialog.wait_window()
+    else:
+        dialog.mainloop()
+
+    return result[0]
 
 
 # System processes that cannot be added as custom processes (safety protection)
@@ -1259,12 +1400,18 @@ def on_save():
 
     # Check if CPU thermal is enabled and Vapor needs to restart with admin privileges
     if new_enable_cpu_thermal and not is_admin():
-        response = messagebox.askyesno(
-            "Admin Privileges Required",
-            "CPU temperature monitoring requires administrator privileges.\n\n"
-            "Would you like to restart Vapor with admin privileges now?\n\n"
-            "Click 'Yes' to restart Vapor as administrator.\n"
-            "Click 'No' to continue without CPU monitoring (will be enabled on next admin restart)."
+        response = show_vapor_dialog(
+            title="Admin Privileges Required",
+            message="CPU temperature monitoring requires administrator privileges.\n\n"
+                    "Would you like to restart Vapor with admin privileges now?\n\n"
+                    "If you click 'Restart as Admin', Vapor will close and relaunch\n"
+                    "with elevated permissions to enable CPU temperature monitoring.",
+            dialog_type="warning",
+            buttons=[
+                {"text": "Restart as Admin", "value": True, "color": "green"},
+                {"text": "Not Now", "value": False, "color": "gray"}
+            ],
+            parent=root
         )
         if response:
             # User agreed to restart with admin
@@ -1273,10 +1420,14 @@ def on_save():
                 root.destroy()
                 return
             else:
-                messagebox.showerror(
-                    "Elevation Failed",
-                    "Failed to restart Vapor with admin privileges.\n"
-                    "Please try running Vapor as administrator manually."
+                show_vapor_dialog(
+                    title="Elevation Failed",
+                    message="Failed to restart Vapor with admin privileges.\n\n"
+                            "Please try running Vapor as administrator manually by\n"
+                            "right-clicking the Vapor shortcut and selecting\n"
+                            "'Run as administrator'.",
+                    dialog_type="error",
+                    parent=root
                 )
 
 


### PR DESCRIPTION
- Created show_vapor_dialog() function for consistent themed popups
- Dialog matches existing DND warning style with Calibri font, buttons
- Supports info/warning/error/question types with colored titles
- Custom button configs with text, value, and color options
- Fixed console window appearing on admin elevation
- Now uses pythonw.exe instead of python.exe when elevating
- Updated admin privilege dialog to use new styled popup

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM