### PR TITLE
Fix dialog icon by setting it after transient relationship

### DIFF
--- a/vapor_settings_ui.py
+++ b/vapor_settings_ui.py
@@ -156,26 +156,20 @@ def show_vapor_dialog(title, message, dialog_type="info", buttons=None, parent=N
     y = (screen_height - height) // 2
     dialog.geometry(f"{width}x{height}+{x}+{y}")
 
-    # Set window icon - try multiple methods for CTkToplevel compatibility
-    icon_path = os.path.join(base_dir, 'Images', 'exe_icon.ico')
-    if os.path.exists(icon_path):
-        def set_icon():
-            try:
-                dialog.iconbitmap(icon_path)
-            except Exception:
-                pass
-            try:
-                dialog.wm_iconbitmap(icon_path)
-            except Exception:
-                pass
-        # Use after with longer delay to ensure window is fully initialized
-        dialog.after(50, set_icon)
-        dialog.after(200, set_icon)  # Try again after window is more stable
-
     # Make dialog modal
     if parent:
         dialog.transient(parent)
     dialog.grab_set()
+
+    # Set window icon AFTER transient relationship (important for CTkToplevel)
+    icon_path = os.path.join(base_dir, 'Images', 'exe_icon.ico')
+    if os.path.exists(icon_path):
+        try:
+            dialog.iconbitmap(icon_path)
+        except Exception:
+            pass
+        # Also try after a short delay for reliability
+        dialog.after(50, lambda: dialog.iconbitmap(icon_path) if dialog.winfo_exists() else None)
 
     # Lift dialog to top and focus
     dialog.lift()


### PR DESCRIPTION
- Moved icon setting to after transient(parent) is established
- CTkToplevel windows need icon set after parent relationship
- Simplified icon setting logic with immediate + delayed attempt
- Added winfo_exists() check in delayed callback for safety

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM