### PR TITLE
Update vapor.spec with temperature monitoring dependencies

### DIFF
--- a/vapor.spec
+++ b/vapor.spec
@@ -12,6 +12,9 @@ a = Analysis(
     datas=[
         ('vapor_settings_ui.py', '.'),
         ('updater.py', '.'),
+        # CPU temperature monitoring (requires LibreHardwareMonitorLib.dll from https://github.com/LibreHardwareMonitor/LibreHardwareMonitor)
+        # Uncomment the line below after placing the DLL in the project root
+        # ('LibreHardwareMonitorLib.dll', '.'),
     ],
     hiddenimports=[
         # Windows API
@@ -28,6 +31,11 @@ a = Analysis(
         'keyboard', 'pystray',
         'watchdog', 'watchdog.observers', 'watchdog.events',
         'win11toast', 'psutil', 'requests', 'certifi', 'urllib3',
+        # Temperature monitoring
+        'pynvml',  # NVIDIA GPU temps
+        'pyadl',   # AMD GPU temps
+        'wmi',     # WMI fallback
+        'clr', 'pythonnet',  # LibreHardwareMonitor for CPU temps
     ] + collect_submodules('customtkinter') + collect_submodules('pycaw') + collect_submodules('comtypes'),
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
Add hidden imports for pynvml (NVIDIA), pyadl (AMD), wmi, and pythonnet/clr for CPU temperature monitoring. Include commented placeholder for LibreHardwareMonitorLib.dll that needs to be added to enable CPU thermal monitoring in packaged builds.

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM