### PR TITLE
Fix indentation error in show_vapor_dialog

### DIFF
--- a/vapor_settings_ui.py
+++ b/vapor_settings_ui.py
@@ -274,8 +274,6 @@ def show_vapor_dialog(title, message, dialog_type="info", buttons=None, parent=N
 
     # Set Vapor icon
     set_vapor_icon(dialog)
-        # Also try after a short delay for reliability
-        dialog.after(50, lambda: dialog.iconbitmap(icon_path) if dialog.winfo_exists() else None)
 
     # Lift dialog to top and focus
     dialog.lift()


### PR DESCRIPTION
Removed orphaned code lines that had incorrect indentation, causing syntax error on startup.

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM