### PR TITLE
Fix PawnIO installation, consolidate logs, and add debug mode restart

### DIFF
--- a/install_pawnio.ps1
+++ b/install_pawnio.ps1
@@ -29,7 +29,7 @@ Write-Host "Winget found at: $($wingetPath.Source)"
 
 # Check if PawnIO is already installed
 Write-Host "Checking if PawnIO is already installed..."
-$installed = winget list --id "PawnIO.PawnIO" 2>$null | Select-String "PawnIO"
+$installed = winget list --id "namazso.PawnIO" 2>$null | Select-String "PawnIO"
 
 if ($installed) {
     Write-Host "PawnIO is already installed." -ForegroundColor Green
@@ -38,9 +38,9 @@ if ($installed) {
 Write-Host "PawnIO not found, proceeding with installation..."
 
 # Install PawnIO
-Write-Host "Running: winget install PawnIO.PawnIO --accept-package-agreements --accept-source-agreements --silent"
+Write-Host "Running: winget install namazso.PawnIO --accept-package-agreements --accept-source-agreements --silent"
 try {
-    $result = winget install PawnIO.PawnIO --accept-package-agreements --accept-source-agreements --silent 2>&1
+    $result = winget install namazso.PawnIO --accept-package-agreements --accept-source-agreements --silent 2>&1
 
     Write-Host "=== Winget Output ===" -ForegroundColor Cyan
     Write-Host $result
@@ -48,7 +48,7 @@ try {
 
     # Check if installation succeeded
     Write-Host "Verifying installation..."
-    $verifyInstall = winget list --id "PawnIO.PawnIO" 2>$null | Select-String "PawnIO"
+    $verifyInstall = winget list --id "namazso.PawnIO" 2>$null | Select-String "PawnIO"
 
     if ($verifyInstall) {
         Write-Host "PawnIO installed successfully." -ForegroundColor Green

--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -463,7 +463,7 @@ from updater import check_for_updates, CURRENT_VERSION
 # =============================================================================
 
 # Log file for debugging (stored in %APPDATA%/Vapor)
-DEBUG_LOG_FILE = os.path.join(appdata_dir, 'vapor_debug.log')
+DEBUG_LOG_FILE = os.path.join(appdata_dir, 'vapor_logs.log')
 
 # Maximum log file size (5 MB) - will be truncated when exceeded
 MAX_LOG_SIZE = 5 * 1024 * 1024

--- a/updater.py
+++ b/updater.py
@@ -37,7 +37,7 @@ pending_update_path = None
 # Log file for debugging (stored in %APPDATA%/Vapor)
 _appdata_dir = os.path.join(os.getenv('APPDATA', ''), 'Vapor')
 os.makedirs(_appdata_dir, exist_ok=True)
-DEBUG_LOG_FILE = os.path.join(_appdata_dir, 'vapor_updater.log')
+DEBUG_LOG_FILE = os.path.join(_appdata_dir, 'vapor_logs.log')
 
 # Maximum log file size (2 MB) - will be truncated when exceeded
 MAX_LOG_SIZE = 2 * 1024 * 1024


### PR DESCRIPTION
PawnIO Fix:
- Use correct winget package ID: namazso.PawnIO (was PawnIO.PawnIO)
- Update error message with manual install instructions

Logging:
- Consolidate all logs into single file: vapor_logs.log
- Remove separate vapor_debug.log, vapor_updater.log, vapor_settings_debug.log

Debug Mode:
- Prompt for restart when debug console setting is changed
- Fixes crash when opening settings after enabling debug mode

https://claude.ai/code/session_014B7GDmPV5tum3PVW78irAM