### PR TITLE
Use alarm scenario for temperature alerts to bypass Do Not Disturb

### DIFF
--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -1061,6 +1061,18 @@ def show_notification(message):
                       audio={'silent': 'true'})
 
 
+def show_temperature_alert(message):
+    """Display a high-priority temperature alert notification that can bypass Do Not Disturb.
+
+    Uses the 'alarm' scenario to ensure the notification appears even when
+    Windows Focus Assist / Do Not Disturb is enabled during gameplay.
+    """
+    log(f"Showing temperature alert: {message}", "ALERT")
+    icon_path = os.path.abspath(TRAY_ICON_PATH)
+    win11toast.notify(body=message, app_id='Vapor - Streamline Gaming', scenario='alarm', icon=icon_path,
+                      audio={'silent': 'true'})
+
+
 def show_brief_summary(session_data):
     """Display a brief toast notification with session summary."""
     hours = session_data['hours']
@@ -1870,15 +1882,15 @@ class TemperatureTracker:
                     self._cpu_critical_triggered = True
                     self._cpu_warning_triggered = True  # Also mark warning as triggered
                     log(f"CPU CRITICAL alert: {cpu_temp}°C exceeds critical threshold of {self._cpu_critical_threshold}°C", "ALERT")
-                    show_notification(f"⚠️ CRITICAL ALERT - CPU Temperature: {cpu_temp}°C{game_info}. "
-                                      f"Critical threshold of {self._cpu_critical_threshold}°C exceeded!")
+                    show_temperature_alert(f"⚠️ CRITICAL ALERT - CPU Temperature: {cpu_temp}°C{game_info}. "
+                                           f"Critical threshold of {self._cpu_critical_threshold}°C exceeded!")
                     self._play_critical_alert_sound()
                 # Check warning level
                 elif not self._cpu_warning_triggered and cpu_temp >= self._cpu_warning_threshold:
                     self._cpu_warning_triggered = True
                     log(f"CPU warning alert: {cpu_temp}°C exceeds warning threshold of {self._cpu_warning_threshold}°C", "ALERT")
-                    show_notification(f"CPU Temperature Warning: {cpu_temp}°C{game_info}. "
-                                      f"Warning threshold of {self._cpu_warning_threshold}°C exceeded.")
+                    show_temperature_alert(f"CPU Temperature Warning: {cpu_temp}°C{game_info}. "
+                                           f"Warning threshold of {self._cpu_warning_threshold}°C exceeded.")
 
             # Check GPU temperature alerts (warning and critical levels)
             if self._enable_gpu_alert and gpu_temp is not None:
@@ -1888,15 +1900,15 @@ class TemperatureTracker:
                     self._gpu_critical_triggered = True
                     self._gpu_warning_triggered = True  # Also mark warning as triggered
                     log(f"GPU CRITICAL alert: {gpu_temp}°C exceeds critical threshold of {self._gpu_critical_threshold}°C", "ALERT")
-                    show_notification(f"⚠️ CRITICAL ALERT - GPU Temperature: {gpu_temp}°C{game_info}. "
-                                      f"Critical threshold of {self._gpu_critical_threshold}°C exceeded!")
+                    show_temperature_alert(f"⚠️ CRITICAL ALERT - GPU Temperature: {gpu_temp}°C{game_info}. "
+                                           f"Critical threshold of {self._gpu_critical_threshold}°C exceeded!")
                     self._play_critical_alert_sound()
                 # Check warning level
                 elif not self._gpu_warning_triggered and gpu_temp >= self._gpu_warning_threshold:
                     self._gpu_warning_triggered = True
                     log(f"GPU warning alert: {gpu_temp}°C exceeds warning threshold of {self._gpu_warning_threshold}°C", "ALERT")
-                    show_notification(f"GPU Temperature Warning: {gpu_temp}°C{game_info}. "
-                                      f"Warning threshold of {self._gpu_warning_threshold}°C exceeded.")
+                    show_temperature_alert(f"GPU Temperature Warning: {gpu_temp}°C{game_info}. "
+                                           f"Warning threshold of {self._gpu_warning_threshold}°C exceeded.")
 
             # Wait for next poll or stop event
             if self._stop_event:


### PR DESCRIPTION
Add show_temperature_alert() function that uses win11toast's 'alarm' scenario, which allows notifications to appear even when Windows Focus Assist / Do Not Disturb is enabled during gameplay.

Updated all CPU and GPU temperature alerts (both warning and critical levels) to use this new function so users receive important thermal warnings during gaming sessions.

https://claude.ai/code/session_01UL2cxaxGAZU4YzwEQ4J9L3