### PR TITLE
Switch temperature alerts from alarm to urgent scenario

### DIFF
--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -1118,7 +1118,7 @@ def show_notification(message):
 def show_temperature_alert(message, is_critical=False):
     """Display a high-priority temperature alert notification that can bypass Do Not Disturb.
 
-    Uses the 'alarm' scenario to ensure the notification appears even when
+    Uses the 'urgent' scenario to ensure the notification appears even when
     Windows Focus Assist / Do Not Disturb is enabled during gameplay.
 
     Args:
@@ -1135,7 +1135,7 @@ def show_temperature_alert(message, is_critical=False):
         # Warning alerts use Windows reminder sound (gentler)
         audio = {'src': 'ms-winsoundevent:Notification.Reminder'}
 
-    win11toast.notify(body=message, app_id='Vapor - Streamline Gaming', scenario='alarm', icon=icon_path,
+    win11toast.notify(body=message, app_id='Vapor - Streamline Gaming', scenario='urgent', icon=icon_path,
                       audio=audio)
 
 


### PR DESCRIPTION
Changed scenario from 'alarm' to 'urgent' for temperature alerts. The urgent scenario is specifically designed for important notifications that should break through Focus Assist/Do Not Disturb, whereas alarm may be more intended for actual alarm clock applications.

https://claude.ai/code/session_01UL2cxaxGAZU4YzwEQ4J9L3