### PR TITLE
Remove scrollbar from game session details window

### DIFF
--- a/steam_game_detector.py
+++ b/steam_game_detector.py
@@ -1256,8 +1256,8 @@ def show_detailed_summary(session_data):
         )
         ok_button.pack()
 
-        # Scrollable content frame (fills remaining space above bottom bar)
-        content_frame = ctk.CTkScrollableFrame(master=popup, fg_color="transparent")
+        # Content frame (fills remaining space above bottom bar)
+        content_frame = ctk.CTkFrame(master=popup, fg_color="transparent")
         content_frame.pack(fill="both", expand=True, padx=15, pady=(20, 10))
 
         # Title


### PR DESCRIPTION
Changed content_frame from CTkScrollableFrame to CTkFrame since the window content is unlikely to need scrolling. Window size remains the same.

https://claude.ai/code/session_01UL2cxaxGAZU4YzwEQ4J9L3